### PR TITLE
[3455] Corrected the kubernetes namespace

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -400,7 +400,7 @@ stages:
           - name: resource_def_name
             value: "stacks-java-api"
           - name: namespace
-            value: "$(Environment.ShortName)-java-api"
+            value: "$(Environment.ShortName)-java-api-cqrs"
           - name: k8s_app_path
             value: "/api/menu"
           - name: dns_pointer
@@ -662,7 +662,7 @@ stages:
           - name: resource_def_name
             value: "stacks-java-api"
           - name: namespace
-            value: "$(Environment.ShortName)-java-api"
+            value: "$(Environment.ShortName)-java-api-cqrs"
           - name: k8s_app_path
             value: "/api/menu"
           - name: dns_pointer


### PR DESCRIPTION
#### 📲 What

Modified the Kubernetes namespace that the application is deployed into

#### 🤔 Why

All apps were deploying into the same namespace with the same name which meant that apps were being deployed over each other.

#### 🛠 How

Changed the `namespace` variable in the deployment stages of the build pipeline

#### 👀 Evidence

The app is now being deployed into the correct namespace

![image](https://user-images.githubusercontent.com/791658/130444525-51fef925-9264-4215-a806-def1e116582d.png)
