### PR TITLE
fix: adds autogen settings.xml file and required cmd's config

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
         <owasp-dependency-check-plugin.version>6.2.2</owasp-dependency-check-plugin.version>
         <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
         <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-        <log4j-version>2.16.0</log4j-version>
+        <log4j-version>2.17.0</log4j-version>
       
         <fmt-maven-plugin.version>2.11</fmt-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>

--- a/stackscli.yml
+++ b/stackscli.yml
@@ -39,9 +39,10 @@ init:
       args: process-resources
               -f stacksclipom.xml
               -P copy-devops-resources
+              -P generate-settings-file
               -Dtarget.dir={{ .Project.Directory.WorkingDir }}
               --quiet
-      desc: Coping build and deploy pipelines into the project structure
+      desc: Copying build and deploy pipelines into the project structure
 
     # Build archetype for the main code
     - action: cmd
@@ -49,6 +50,7 @@ init:
       args: clean archetype:create-from-project
               -f ./java/pom.xml
               -DpropertyFile=./java/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the cqrs component
 
@@ -119,6 +121,7 @@ init:
       args: clean archetype:create-from-project
               -f ./api-tests/pom-temp.xml
               -DpropertyFile=./api-tests/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the api-test source code
 
@@ -179,6 +182,7 @@ init:
       args: clean archetype:create-from-project
               -f ./api-tests-karate/pom.xml
               -DpropertyFile=./api-tests-karate/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the api-test-karate source code
 
@@ -215,3 +219,12 @@ init:
               -f {{ .Project.Directory.WorkingDir }}/api-tests-karate/pom.xml
               --quiet
       desc: Downloading maven dependencies for the api-tests-karate project
+
+    - action: cmd
+      cmd: mvn
+      args: clean
+              -f stacksclipom.xml
+              -P clean-workload
+              -Dtarget.dir={{ .Project.Directory.WorkingDir }}
+              --quiet
+      desc: Cleaning the project folder

--- a/stacksclipom.xml
+++ b/stacksclipom.xml
@@ -88,6 +88,39 @@
     </profile>
 
     <profile>
+      <id>generate-settings-file</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>ru.yaal.maven</groupId>
+            <artifactId>write-text-files-maven-plugin</artifactId>
+            <version>1.1</version>
+            <configuration>
+              <charset>UTF-8</charset>
+              <files>
+                <file>
+                  <path>${output.basedir}/settings.xml</path>
+                  <lines>
+                    <line><![CDATA[<settings></settings>]]></line>
+                  </lines>
+                </file>
+              </files>
+            </configuration>
+            <executions>
+              <execution>
+                <id>generate-settings-file</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>write-text-files</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
+    <profile>
       <id>rename-source-folder</id>
       <build>
         <plugins>
@@ -108,6 +141,29 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>clean-workload</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>${output.basedir}</directory>
+                  <includes>
+                    <include>**/settings.xml</include>
+                  </includes>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
4074-Settings.xml file not present

📲 What

Autogenerates the maven settings.xml file
🤔 Why

The archetype:generate-from-project needs the settings.xml to be present in the local environment. As this is not a mandatory maven file, we need to ensure that a version exists, if not the build will fail.
🛠 How

Plugin (write-text-files-maven-plugin) capable to generate files has been added to the stacksclipom.xml file
```

<groupId>ru.yaal.maven</groupId>
<artifactId>write-text-files-maven-plugin</artifactId>
<version>1.1</version>
```

Also two new profiles were added (generate-settings-file and clean-workload)

- generate-settings-file. Is responsible for generate and store a temp settings file in ${output.basedir}/settings.xml
- clean-workload. Deletes the file once the entire CLI process is completed.


#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
