### PR TITLE
4710 - Added CosmosDB dependency so as to fix unit tests (and fixed formatting)

### DIFF
--- a/java/src/test/java/com/amido/stacks/workloads/actuator/ActuatorTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/actuator/ActuatorTest.java
@@ -22,19 +22,20 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Component")
 class ActuatorTest {
 
   @Value("${local.management.port}")
   private int mgt;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void shouldReturn200WhenSendingRequestToHealthEndpoint() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateCategoryControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateCategoryControllerImplTest.java
@@ -37,22 +37,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class CreateCategoryControllerImplTest {
 
   public static final String CREATE_CATEGORY = "%s/v1/menu/%s/category";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testCanNotAddCategoryIfMenuNotPresent() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateItemControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateItemControllerImplTest.java
@@ -43,21 +43,21 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class CreateItemControllerImplTest {
 
   public static final String CREATE_ITEM = "%s/v1/menu/%s/category/%s/items";
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testAddItem() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateMenuControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/CreateMenuControllerImplTest.java
@@ -34,22 +34,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class CreateMenuControllerImplTest {
 
   public static final String CREATE_MENU = "/v1/menu";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testCreateNewMenu() {
@@ -60,7 +60,7 @@ class CreateMenuControllerImplTest {
             m.getName(), m.getDescription(), UUID.fromString(m.getRestaurantId()), m.getEnabled());
 
     when(menuRepository.findAllByRestaurantIdAndName(
-        eq(m.getRestaurantId()), eq(m.getName()), any(Pageable.class)))
+            eq(m.getRestaurantId()), eq(m.getName()), any(Pageable.class)))
         .thenReturn(new PageImpl<>(Collections.emptyList()));
     when(menuRepository.save(any(Menu.class))).thenReturn(m);
 
@@ -82,7 +82,7 @@ class CreateMenuControllerImplTest {
             m.getName(), m.getDescription(), UUID.fromString(m.getRestaurantId()), m.getEnabled());
 
     when(menuRepository.findAllByRestaurantIdAndName(
-        eq(m.getRestaurantId()), eq(m.getName()), any(Pageable.class)))
+            eq(m.getRestaurantId()), eq(m.getName()), any(Pageable.class)))
         .thenReturn(new PageImpl<>(Arrays.asList(m)));
 
     // When

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteCategoryControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteCategoryControllerImplTest.java
@@ -38,22 +38,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class DeleteCategoryControllerImplTest {
 
   public static final String DELETE_CATEGORY = "%s/v1/menu/%s/category/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository repository;
+  @MockBean private MenuRepository repository;
 
   @Test
   void testDeleteCategorySuccess() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteItemControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteItemControllerImplTest.java
@@ -36,27 +36,25 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
-/**
- * @author ArathyKrishna
- */
+/** @author ArathyKrishna */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class DeleteItemControllerImplTest {
 
   public static final String DELETE_ITEM = "%s/v1/menu/%s/category/%s/items/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository repository;
+  @MockBean private MenuRepository repository;
 
   @AfterEach
   void tearDown() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteMenuControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/DeleteMenuControllerImplTest.java
@@ -34,22 +34,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class DeleteMenuControllerImplTest {
 
   public static final String DELETE_MENU = "%s/v1/menu/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository repository;
+  @MockBean private MenuRepository repository;
 
   @Test
   void testDeleteMenuSuccess() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/QueryMenuControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/QueryMenuControllerImplTest.java
@@ -46,20 +46,20 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 public class QueryMenuControllerImplTest {
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   final int DEFAULT_PAGE_NUMBER = 1;
   final int DEFAULT_PAGE_SIZE = 20;
@@ -132,7 +132,7 @@ public class QueryMenuControllerImplTest {
     final String searchTerm = "searchTermString";
 
     when(menuRepository.findAllByRestaurantIdAndNameContaining(
-        eq(restaurantId.toString()), eq(searchTerm), any(Pageable.class)))
+            eq(restaurantId.toString()), eq(searchTerm), any(Pageable.class)))
         .thenReturn(new PageImpl<>(Collections.emptyList()));
 
     // When

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateCategoryControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateCategoryControllerImplTest.java
@@ -44,22 +44,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class UpdateCategoryControllerImplTest {
 
   public static final String UPDATE_CATEGORY = "%s/v1/menu/%s/category/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testUpdateCategorySuccess() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateItemControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateItemControllerImplTest.java
@@ -41,27 +41,25 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
-/**
- * @author ArathyKrishna
- */
+/** @author ArathyKrishna */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class UpdateItemControllerImplTest {
 
   public static final String UPDATE_ITEM = "%s/v1/menu/%s/category/%s/items/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testUpdateItemSuccess() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateMenuControllerImplTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v1/impl/UpdateMenuControllerImplTest.java
@@ -36,22 +36,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class UpdateMenuControllerImplTest {
 
   public static final String UPDATE_MENU = "%s/v1/menu/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void testUpdateSuccess() {

--- a/java/src/test/java/com/amido/stacks/workloads/menu/api/v2/impl/QueryMenuControllerImplV2Test.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/api/v2/impl/QueryMenuControllerImplV2Test.java
@@ -28,22 +28,22 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
-    exclude = {CosmosRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class,
-        CosmosHealthConfiguration.class})
+    exclude = {
+      CosmosRepositoriesAutoConfiguration.class,
+      CosmosAutoConfiguration.class,
+      CosmosHealthConfiguration.class
+    })
 @Tag("Integration")
 @ActiveProfiles("test")
 class QueryMenuControllerImplV2Test {
 
   private final String GET_MENU_BY_ID = "%s/v2/menu/%s";
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-  @MockBean
-  private MenuRepository menuRepository;
+  @MockBean private MenuRepository menuRepository;
 
   @Test
   void getMenuById() {


### PR DESCRIPTION

4710 - Added missing CosmosDB dependency so as to fix unit tests (and fixed formatting)

#### 📲 What

Added missing dependency (CosmosHealthConfiguration.class) to the auto config exclude so as to fix unit tests 

#### 🤔 Why

Unit tests were failing as no config could be found for CosmosDB health checks

#### 🛠 How

By excluding CosmosHealthConfiguration.class from the Spring Auto config it now no longer needs the config that was failing.

#### 👀 Evidence

Unit tests were failing

#### 🕵️ How to test

1. Clone repository
2. `cd java`
3. `mvn clean test`

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [✅] Passing all automated tests, including a successful deployment?
- [✅] Passing any exploratory testing?
- [✅] Rebased/merged with latest changes from development and re-tested?
- [✅] Meeting the Coding Standards?
