### PR TITLE
hotfix(): update deps httpclient5 & spring-web

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -44,10 +44,10 @@
     <netty.codec.http2.version>4.1.115.Final</netty.codec.http2.version>
     <netty.transport.native.epoll.version>4.1.115.Final</netty.transport.native.epoll.version>
     <guava.version>33.3.1-jre</guava.version>
-    <httpclient5.version>5.4.1</httpclient5.version>
+    <httpclient5.version>5.4.3</httpclient5.version>
     <xerces.version>2.12.2</xerces.version>
     <commons.codec.version>1.17.1</commons.codec.version>
-    <spring.web.version>6.2.0</spring.web.version>
+    <spring.web.version>6.2.8</spring.web.version>
     <com.google.code.gson.version>2.11.0</com.google.code.gson.version>
     <net.thucydides.core.version>0.9.275</net.thucydides.core.version>
     <rest-assured.version>5.5.0</rest-assured.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,7 @@
     <java.version>17</java.version>
     <org.projectlombok.version>1.18.34</org.projectlombok.version>
     <applicationinsights.version>3.5.4</applicationinsights.version>
-    <logback.version>1.5.12</logback.version>
+    <logback.version>1.5.13</logback.version>
     <com.google.code.gson-version>2.11.0</com.google.code.gson-version>
     <pitest.version>1.17.1</pitest.version>
     <jacoco.version>0.8.12</jacoco.version>


### PR DESCRIPTION


#### 📲 What

Update deps httpclient5 & spring-web

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of webpack-dev-server, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Manually updated pom.exe, clean, compile and test.

#### 👀 Evidence

```
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.498 s
[INFO] Finished at: 2025-06-27T11:36:32+01:00
[INFO] ------------------------------------------------------------------------
```

#### 🕵️ How to test

```
git clean -dfx
cd java
./mvnw clean install test -Plocal
```

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
