### PR TITLE
fix: bump netty to mitigate CVE-2026-42577

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -40,9 +40,9 @@
     <springfox.swagger2.version>3.0.0</springfox.swagger2.version>
     <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
     <json.version>20240303</json.version>
-    <netty.codec.http.version>4.2.12.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.2.12.Final</netty.codec.http2.version>
-    <netty.transport.native.epoll.version>4.2.12.Final</netty.transport.native.epoll.version>
+    <netty.codec.http.version>4.2.13.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.13.Final</netty.codec.http2.version>
+    <netty.transport.native.epoll.version>4.2.13.Final</netty.transport.native.epoll.version>
     <guava.version>33.4.8-jre</guava.version>
     <httpclient5.version>5.5</httpclient5.version>
     <xerces.version>2.12.2</xerces.version>


### PR DESCRIPTION
#### 📲 What

Bumps netty to mitigate CVE-2026-42577

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Edited `pom.xml`

#### 👀 Evidence

CI

#### 🕵️ How to test

CI

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
