### PR TITLE
fix: bump postcss

### DIFF
--- a/build/azDevOps/azure/coverage/package-lock.json
+++ b/build/azDevOps/azure/coverage/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "coverage",
       "license": "Apache-2.0",
       "devDependencies": {
         "gulp": "^5.0.1",
@@ -12,7 +13,7 @@
         "postcss-image-inliner": "^7.0.1"
       },
       "engines": {
-        "node": ">=20.16.0 <21"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2338,7 +2339,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2672,8 +2672,8 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {

--- a/build/azDevOps/azure/coverage/package.json
+++ b/build/azDevOps/azure/coverage/package.json
@@ -2,16 +2,16 @@
   "description": "N/A",
   "license": "Apache-2.0",
   "repository": "N/A",
-
   "engines": {
     "node": ">=20.16.0 <21"
   },
-
   "devDependencies": {
     "gulp": "^5.0.1",
     "gulp-postcss": "^10.0.0",
     "inline-source": "^8.0.3",
     "postcss-image-inliner": "^7.0.1"
+  },
+  "overrides": {
+    "postcss": ">=8.5.10"
   }
-
 }

--- a/build/azDevOps/azure/coverage/package.json
+++ b/build/azDevOps/azure/coverage/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "repository": "N/A",
   "engines": {
-    "node": ">=20.16.0 <21"
+    "node": ">=24"
   },
   "devDependencies": {
     "gulp": "^5.0.1",


### PR DESCRIPTION
#### 📲 What

Bumps `postcss` to mitigate CVE-2026-41305

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Update `package.json` with override.

#### 👀 Evidence

```
 $ npm ls postcss
coverage@ /home/rslater/source/stacks-java-cqrs/build/azDevOps/azure/coverage
├─┬ gulp-postcss@10.0.0
│ ├─┬ postcss-load-config@5.1.0
│ │ └── postcss@8.5.14 deduped
│ └── postcss@8.5.14
└─┬ postcss-image-inliner@7.0.1
  └── postcss@8.5.14 deduped

 $ npm audit
found 0 vulnerabilities
```

#### 🕵️ How to test

CI

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
